### PR TITLE
fix: 修复 CORS 头部未允许 jike access token 问题

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -2,11 +2,12 @@ package service
 
 import (
 	"fmt"
+	"log"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/ultrazg/xyz/router"
 	"github.com/ultrazg/xyz/utils"
-	"log"
-	"net/http"
 )
 
 func Start() error {
@@ -55,7 +56,7 @@ func Cors() gin.HandlerFunc {
 		method := context.Request.Method
 
 		context.Header("Access-Control-Allow-Origin", "*")
-		context.Header("Access-Control-Allow-Headers", "Content-Type,AccessToken,X-CSRF-Token, Authorization, Token, x-token")
+		context.Header("Access-Control-Allow-Headers", "Content-Type, AccessToken, X-CSRF-Token, Authorization, Token, x-token, x-jike-access-token, x-jike-refresh-token")
 		context.Header("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE, PATCH, PUT")
 		context.Header("Access-Control-Expose-Headers", "Content-Length, Access-Control-Allow-Origin, Access-Control-Allow-Headers, Content-Type")
 		context.Header("Access-Control-Allow-Credentials", "true")


### PR DESCRIPTION
文档以及 `utils/token.go` 中都表示识别 `x-jike-access-token` 这个 header 作为 auth 凭据，但实际上 cors 设置中未允许这个 header，需要简单修复一下（不确定 refresh-token 需不需要，貌似刷新 token 是在 body 中传的）