### PR TITLE
Fix SMS login empty response handling

### DIFF
--- a/handlers/login.go
+++ b/handlers/login.go
@@ -89,7 +89,6 @@ var Login = func(ctx *gin.Context) {
 	url := "https://podcaster-api.xiaoyuzhoufm.com/v1/auth/login-with-sms"
 	headers := map[string]string{
 		"accept":          "application/json, text/plain, */*",
-		"accept-encoding": "gzip, deflate, br, zstd",
 		"accept-language": "zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6",
 		"content-type":    "application/json;charset=UTF-8",
 		"origin":          "https://podcaster.xiaoyuzhoufm.com",
@@ -112,6 +111,11 @@ var Login = func(ctx *gin.Context) {
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		log.Println("Error reading response body:", err)
+		ctx.JSON(http.StatusBadGateway, gin.H{
+			"code": http.StatusBadGateway,
+			"msg":  utils.GetMsg(http.StatusBadGateway),
+			"data": "failed to read upstream login response",
+		})
 
 		return
 	}
@@ -120,6 +124,11 @@ var Login = func(ctx *gin.Context) {
 	err = json.Unmarshal(body, &data)
 	if err != nil {
 		log.Println("Error parsing response body:", err)
+		ctx.JSON(http.StatusBadGateway, gin.H{
+			"code": http.StatusBadGateway,
+			"msg":  utils.GetMsg(http.StatusBadGateway),
+			"data": "failed to parse upstream login response",
+		})
 
 		return
 	}

--- a/handlers/sendcode.go
+++ b/handlers/sendcode.go
@@ -41,7 +41,6 @@ var SendCode = func(ctx *gin.Context) {
 	url := "https://podcaster-api.xiaoyuzhoufm.com/v1/auth/send-code"
 	headers := map[string]string{
 		"accept":          "application/json, text/plain, */*",
-		"accept-encoding": "gzip, deflate, br, zstd",
 		"accept-language": "zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6",
 		"content-type":    "application/json;charset=UTF-8",
 		"origin":          "https://podcaster.xiaoyuzhoufm.com",

--- a/utils/http.go
+++ b/utils/http.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 )
@@ -28,31 +27,6 @@ func Request(url, method string, body map[string]any, headers map[string]string)
 		for key, value := range headers {
 			req.Header.Set(key, value)
 		}
-
-		fmt.Println("=========[REQUEST INFO]=========")
-		fmt.Println("Request Url:", url)
-		fmt.Println("Request Method:", method)
-
-		if req.Body != nil {
-			requestBody := req.Body
-			var requestBodyBytes []byte
-			if requestBody != nil {
-				requestBodyBytes, _ = io.ReadAll(requestBody)
-			}
-
-			fmt.Println("Request Body:", string(requestBodyBytes))
-
-			req.Body = io.NopCloser(bytes.NewBuffer(requestBodyBytes))
-		}
-
-		fmt.Println("Request Headers:")
-		for key, values := range req.Header {
-			for _, value := range values {
-				fmt.Printf("%s: %s\n", key, value)
-			}
-		}
-
-		fmt.Println("========================")
 	}
 
 	var resp *http.Response


### PR DESCRIPTION
## Summary

- stop manually sending `Accept-Encoding` on SMS auth requests so Go can handle response compression normally
- return `502` JSON when the upstream login body cannot be read or parsed instead of leaving clients with an empty `200`
- remove request body/header debug logging to avoid printing SMS codes or auth headers

## Why

During SMS login, `/login` can return HTTP 200 with an empty body when upstream login response parsing fails. Clients cannot distinguish this from success and cannot recover.

The SMS auth requests manually set `Accept-Encoding: gzip, deflate, br, zstd`. In Go, manually setting `Accept-Encoding` prevents the default transport from applying its normal gzip decompression behavior. Removing the header lets `net/http` manage compression safely.

Fixes #28

## Verification

- `go test ./...`
- local SMS login against a patched server successfully returned and saved access/refresh tokens; credentials are intentionally not included here
